### PR TITLE
User-friendliness fixes

### DIFF
--- a/theme.html
+++ b/theme.html
@@ -33,7 +33,7 @@
 ==============================================================================
 -->
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "//www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
 <html xmlns="//www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="<$BlogLanguageDirection$>">
 
@@ -108,13 +108,11 @@
         background-color: #888;
         color: black;
         counter-reset: figure;
-        cursor: default;
         font: 600 16px Bitter, serif;
         margin: 20px 0 25px 0 !important;
         overflow: overlay;
         overflow-x: hidden;
         text-align: center;
-        user-select: none;
       }
 
       ::-webkit-scrollbar {


### PR DESCRIPTION
Restores the ability to select text, as it's frustrating and generally unnecessary to deny the ability to do that.

This allows users to quicky copy and reference release information when needed.